### PR TITLE
Add readOnly property where appropriate in the json schema's.

### DIFF
--- a/schemas/oic.core-schema.json
+++ b/schemas/oic.core-schema.json
@@ -16,6 +16,7 @@
             }
           ],
           "minItems" : 1,
+          "readOnly": true,
           "description": "ReadOnly, Resource Type"
         },
         "if": {
@@ -27,16 +28,19 @@
             }
           ],
           "minItems": 1,
+          "readOnly": true,
           "description": "ReadOnly, The interface set supported by this resource"
         },
         "n": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Friendly name of the resource"
         },
         "id": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Instance ID of this specific resource"
         }
       }

--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -27,6 +27,7 @@
             }
           ],
           "minItems" : 1,
+          "readOnly": true,
           "description": "ReadOnly, Resource Type"
         },
         "if": {
@@ -38,6 +39,7 @@
             }
           ],
           "minItems": 1,
+          "readOnly": true,
           "description": "ReadOnly, The interface set supported by this resource"
         },
         "di": {
@@ -52,18 +54,22 @@
           "format": "uri"
         },
         "p": {
+          "readOnly": true,
           "description": "ReadOnly, Specifies the framework policies on the Resource referenced by the target URI",
           "type": "object",
           "properties": {
             "bm": {
+              "readOnly": true,
               "description": "ReadOnly, Specifies the framework policies on the Resource referenced by the target URI for e.g. observable and discoverable",
               "type": "integer"
             },
             "sec": {
+              "readOnly": true,
               "description": "ReadOnly, Specifies if security needs to be turned on when looking to interact with the Resource",
               "type": "boolean"
             },
             "port": {
+              "readOnly": true,
               "description": "ReadOnly, Secure port to be used for connection",
               "type": "integer"
             },

--- a/schemas/oic.rule-Update-schema.json
+++ b/schemas/oic.rule-Update-schema.json
@@ -14,6 +14,7 @@
         },
                 "currentStatus": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, the current state, can be one of: enabled, disabled, error"
         },
         "n": {
@@ -31,6 +32,7 @@
         },
         "rts": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Defines the list of allowable resource types in links included in the collection; new links being created can only be from this list"
         },
                 "links": {

--- a/schemas/oic.rule-schema.json
+++ b/schemas/oic.rule-schema.json
@@ -14,6 +14,7 @@
         },
                 "currentStatus": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, the current state, can be one of: enabled, disabled, error"
         },
         "n": {
@@ -31,6 +32,7 @@
         },
         "rts": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Defines the list of allowable resource types in links included in the collection; new links being created can only be from this list"
         },
                 "links": {

--- a/schemas/oic.ruleMember-schema.json
+++ b/schemas/oic.ruleMember-schema.json
@@ -18,6 +18,7 @@
         },
         "memberProperty": {
           "type":  "string",
+          "readOnly": true,
           "description": "ReadOnly, property name that will be mapped"
         },
         "memberValue": {
@@ -26,6 +27,7 @@
             { "type": "string",  "description":  "if member property is an number" },
             { "type": "boolean", "description": "if member property is an boolean" }
           ],
+          "readOnly": true,
           "description": "ReadOnly, value of the Member Property"
         },
         "link": {

--- a/schemas/oic.sceneCollection-Update-schema.json
+++ b/schemas/oic.sceneCollection-Update-schema.json
@@ -14,6 +14,7 @@
         },
         "sceneValues": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, All available scene values",
           "format": "CSV"
         },
@@ -28,6 +29,7 @@
         },
         "rts": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Defines the list of allowable resource types in links included in the collection; new links being created can only be from this list",
           "format": "UTF8"
         },

--- a/schemas/oic.sceneCollection-schema.json
+++ b/schemas/oic.sceneCollection-schema.json
@@ -14,6 +14,7 @@
         },
         "sceneValues": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, All available scene values",
           "format": "CSV"
         },
@@ -28,6 +29,7 @@
         },
         "rts": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Defines the list of allowable resource types in links included in the collection; new links being created can only be from this list",
           "format": "UTF8"
         },

--- a/schemas/oic.sceneMember-schema.json
+++ b/schemas/oic.sceneMember-schema.json
@@ -29,10 +29,12 @@
                 },
                 "memberProperty": {
                   "type":  "string",
+                  "readOnly": true,
                   "description": "ReadOnly, property name that will be mapped"
                 },
                   "memberValue": {
                   "type": "string",
+                  "readOnly": true,
                   "description": "ReadOnly, value of the Member Property"
                 }
               },

--- a/schemas/oic.wk.d-schema.json
+++ b/schemas/oic.wk.d-schema.json
@@ -15,16 +15,19 @@
           "type": "string",
           "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
           "format": "uuid",
+          "readOnly": true,
           "description": "ReadOnly, Unique identifier for device (UUID)"
         },
         "icv": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, The version of the OIC Server"
         },
         "dmv": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, The spec version of the vertical and/or resource specification"
         }
       }

--- a/schemas/oic.wk.mon-schema.json
+++ b/schemas/oic.wk.mon-schema.json
@@ -8,10 +8,12 @@
       "properties": {
         "av":{
           "type": "boolean",
+          "readOnly": true,
           "description": "ReadOnly, Indicates if the device is available or not on the network (like ping)"
         },
         "lat": {
           "type": "integer",
+          "readOnly": true,
           "description": "ReadOnly, Indicates the elapsed time in seconds after the device was invoked or acted upon"
         },
         "ds": {
@@ -22,6 +24,7 @@
               "maxLength": 64
             }
           ],
+          "readOnly": true,
           "description": "ReadOnly, Contains Device Statistics Info (no. of received packets, no. of sent packets, time to respond etc.)"
         }
       }

--- a/schemas/oic.wk.p-schema.json
+++ b/schemas/oic.wk.p-schema.json
@@ -10,15 +10,18 @@
           "type": "string",
           "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
           "format": "uuid",
+          "readOnly": true,
           "description": "ReadOnly, Platform Identifier as a UUID"
         },
         "mnmn": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Manufacturer Name",
           "maxLength": 64
         },
         "mnml": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Manufacturer's URL",
           "maxLength": 256,
           "format": "uri"
@@ -26,10 +29,12 @@
         "mnmo": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Model number as designated by manufacturer"
         },
         "mndt": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Manufacturing Date as defined in ISO 8601, where the format is [yyyy]-[mm]-[dd].",
           "pattern": "^([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|2[0-9]|1[0-9]|0[1-9])$",
           "format": "date-time"
@@ -37,6 +42,7 @@
         "mnpv": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Platform Version"
         },
         "mnos": {
@@ -52,16 +58,19 @@
         "mnfv": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Manufacturer's firmware version"
         },
         "mnsl": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Manufacturer's Support Information URL",
           "maxLength": 256,
           "format": "uri"
         },
         "st": {
           "type": "string",
+          "readOnly": true,
           "description": "ReadOnly, Reference time for the device as defined in ISO 8601, where concatenation of 'date' and 'time' with the 'T' as a delimiter between 'date' and 'time'. The format is [yyyy]-[mm]-[dd]T[hh]:[mm]:[ss]Z.",
           "pattern": "^([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|2[0-9]|1[0-9]|0[1-9])T(2[0-3]|1[0-9]|0[0-9]):([0-5][0-9]):([0-5][0-9])Z$",
           "format": "date-time"
@@ -69,6 +78,7 @@
         "vid": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Manufacturer's defined string for the platform. The string is freeform and up to the manufacturer on what text to populate it"
         }
       }

--- a/schemas/oic.wk.res-schema.json
+++ b/schemas/oic.wk.res-schema.json
@@ -9,15 +9,18 @@
         "n": {
           "type": "string",
           "maxLength": 64,
+          "readOnly": true,
           "description": "ReadOnly, Human friendly name"
         },
         "di": {
           "type": "string",
           "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
           "format": "uuid",
+          "readOnly": true,
           "description": "ReadOnly, Unique identifier for device (UUID) as indicated by the /oic/d resource of the device"
         },
         "mpro": {
+          "readOnly": true,
           "description": "ReadOnly, Supported messaging protocols",
           "type": "string",
           "maxLength": 64


### PR DESCRIPTION
This change is to make the readOnly properties machine readable and is
compliant with the JSON-hyper schema definition. See:
http://json-schema.org/latest/json-schema-hypermedia.html#anchor15
