### PR TITLE
Editoral fix to v1.1.1

### DIFF
--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -35,7 +35,7 @@
           "items": [
             {
               "type" : "string",
-              "enum" : ["oic.if.baseline", "oic.if.ll", "oic.if.b", "oic.if.lb", "oic.if.rw", "oic.if.r", "oic.if.a", "oic.if.s" ]
+              "enum" : ["oic.if.baseline", "oic.if.ll", "oic.if.b", "oic.if.rw", "oic.if.r", "oic.if.a", "oic.if.s" ]
             }
           ],
           "minItems": 1,
@@ -66,6 +66,7 @@
             "sec": {
               "readOnly": true,
               "description": "Specifies if security needs to be turned on when looking to interact with the Resource",
+              "default": false,
               "type": "boolean"
             },
             "port": {

--- a/schemas/oic.rule-schema.json
+++ b/schemas/oic.rule-schema.json
@@ -40,7 +40,7 @@
           "description": "Array of OIC web links that are the rule members, this is the script",
           "items" : {
             "allOf": [
-              { "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link#" },
+              { "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link" },
               { "required" : [ "ins" ] }
             ]
           }

--- a/schemas/oic.types-schema.json
+++ b/schemas/oic.types-schema.json
@@ -6,12 +6,12 @@
         "uuid": {
             "description": "An identifier formatted according to IETF RFC 4122.",
             "type":"string",
-            "format": "date-time",
             "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
         },
         "date": {
             "description": "As defined in ISO 8601. The format is [yyyy]-[mm]-[dd].",
             "type": "string",
+            "format": "date-time",
             "pattern": "^([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|2[0-9]|1[0-9]|0[1-9])$"
         }
     }


### PR DESCRIPTION
Per Mitch Kittrick:
1.  oic.rule-schema.json (Bug 1146)
   
   "links": {
           "type": "array",
           "description": "Array of OIC web links that are the rule members, this is the script",
           "items" : {
             "allOf": [
               { "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link#" },
               { "required" : [ "ins" ] }
             ]
           }
         }
   },

The “#” need to be removed.
1.  oic.types-schema.json

"uuid": {
            "description": "An identifier formatted according to IETF RFC 4122.",
            "type":"string",
            "format": "date-time",
            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
},

I can’t recall if we agreed to keep the “format” for “uuid” but if we did, it should not be “date-time”.  
1.  oic.oic-link-schema.json

"if": {
          "type": "array",
          "items": [
            {
              "type" : "string",
              "enum" : ["oic.if.baseline", "oic.if.ll", "oic.if.b", "oic.if.lb", "oic.if.rw", "oic.if.r", "oic.if.a", "oic.if.s" ]
            }
          ],
          "minItems": 1,
          "readOnly": true,
          "description": "The interface set supported by this resource"
},

oic.if.lb was removed from the core spec.
1.  oic.oic-link-shema.json

"sec": {
              "readOnly": true,
              "description": "Specifies if security needs to be turned on when looking to interact with the Resource",
              "type": "boolean"
},

Per CR 48, we had agreed that the default value of “sec” is false.  The schema file use to include: “default”: false.  Do we no longer include the default value in the schema file?
