### PR TITLE
Fix validation errors in examples of oic.wk.col.raml

### DIFF
--- a/oic.wk.col.raml
+++ b/oic.wk.col.raml
@@ -77,13 +77,13 @@ traits:
                 "links": [
                   {
                     "href": "switch",
-                    "rt":   "oic.r.switch.binary",
-                    "if":   "oic.if.a"
+                    "rt":   ["oic.r.switch.binary"],
+                    "if":   ["oic.if.a"]
                   },
                   {
                     "href": "airFlow",
-                    "rt":   "oic.r.airFlow",
-                    "if":   "oic.if.a"
+                    "rt":   ["oic.r.airFlow"],
+                    "if":   ["oic.if.a"]
                   }
                 ]
               }
@@ -219,12 +219,12 @@ traits:
                 [
                   {
                     "href": "switch",
-                    "rt":   "oic.r.switch.binary",
-                    "if":   "oic.if.a"
+                    "rt":   ["oic.r.switch.binary"],
+                    "if":   ["oic.if.a"]
                   },
                   {
                     "href": "airFlow",
-                    "rt":   "oic.r.airFlow",
-                    "if":   "oic.if.a"
+                    "rt":   ["oic.r.airFlow"],
+                    "if":   ["oic.if.a"]
                   }
                 ]

--- a/schemas/oic.collection-schema.json
+++ b/schemas/oic.collection-schema.json
@@ -117,7 +117,7 @@
                     "description": "The device ID which is an UUIDv4 string; used for backward compatibility with Spec A defintion of /oic/res"
                 },
                 "rts": {
-                    "type": "string",
+                    "$ref": "oic.core-schema.json#/definitions/oic.core/properties/rt",
                     "description": "Defines the list of allowable resource types (for Target and anchors) in links included in the collection; new links being created can only be from this list"                },
                 "drel": {
                     "type": "string",


### PR DESCRIPTION
The rt and if attributes in the examples required an array of strings.
The type rts in a collections is now streamlined with the rt type which
is an array for strings.
