### PR TITLE
Added definition of "uuid-or-star"

### DIFF
--- a/schemas/oic.types-schema.json
+++ b/schemas/oic.types-schema.json
@@ -8,6 +8,10 @@
             "type":"string",
             "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
         },
+        "uuid-or-star": {
+            "type":"string",
+            "pattern": "^([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})|[*]$"
+        },
         "date": {
             "description": "As defined in ISO 8601. The format is [yyyy]-[mm]-[dd].",
             "type": "string",


### PR DESCRIPTION
subjectuuid in security credential definitions needs to support the use of "*" in place of an explicit UUID. This change adds a definition called "uuid-or-star" which supports "*" in place of the UUID.
