### PR TITLE
Removed the link tag and added "rep" keyword

### DIFF
--- a/oic.wk.col.raml
+++ b/oic.wk.col.raml
@@ -127,12 +127,18 @@ traits:
                 [
                   {
                     "href": "switch",
-                    "value": true
+                    "rep":
+                      {
+                        "value": true
+                      }
                   },
                   {
                     "href": "airFlow",
-                    "direction": "floor",
-                    "speed":      3
+                    "rep":
+                      {
+                        "direction": "floor",
+                        "speed":      3
+                      }
                   }
                 ]
         404:
@@ -144,7 +150,10 @@ traits:
                 [
                   {
                     "href": "switch",
-                    "value": true
+                    "rep":
+                      {
+                        "value": true
+                      }
                   }
                 ]
 
@@ -171,12 +180,18 @@ traits:
                 [
                   {
                     "href": "switch",
-                    "value": true
+                    "rep":
+                      {
+                        "value": true
+                      }
                   },
                   {
                     "href": "airFlow",
-                    "direction": "demist",
-                    "speed": 5
+                    "rep":
+                      {
+                        "direction": "demist",
+                        "speed": 5
+                      }
                   }
                 ]
 
@@ -189,12 +204,18 @@ traits:
                 [
                   {
                     "href": "switch",
-                    "value": true
+                    "rep":
+                      {
+                        "value": true
+                      }
                   },
                   {
                     "href": "airFlow",
-                    "direction": "floor",
-                    "speed": 3
+                    "rep":
+                      {
+                        "direction": "floor",
+                        "speed": 3
+                      }
                   }
                 ]
 

--- a/schemas/oic.collection-schema.json
+++ b/schemas/oic.collection-schema.json
@@ -11,74 +11,9 @@
                 "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link"
             }
         },
-        "oic.collection.tags": {
-            "type": "object",
-            "description": "The tags that can be used for tagging links in a collection",
-            "properties": {
-                "n": {
-                    "type": "string",
-                    "description": "Used to name i.e. tag the set of links"
-                },
-                "id": {
-                    "description": "Id for each set of links i.e. tag. Can be an value that is unique to the use context or a UUIDv4",
-                    "anyOf": [
-                        {
-                            "type": "integer",
-                            "description": "A number that is unique to that collection; like an ordinal number that is not repeated"
-                        },
-                        {
-                            "type": "string",
-                            "description": "A unique string that could be a hash or similarly unique"
-                        },
-                        {
-                            "$ref": "oic.types-schema.json#/definitions/uuid",
-                            "description": "A unique string that could be a UUIDv4"
-                        }
-                    ]
-                },
-                "di": {
-                    "$ref": "oic.types-schema.json#/definitions/uuid",
-                    "description": "The device ID which is an UUIDv4 string"
-                },
-                "base": {
-                    "type": "string",
-                    "description": "The base URI to be used if the links are relative URIs  (i.e. relative references); see base URI in Core spec for details",
-                    "format": "uri"
-                }
-            },
-            "minProperties": 1
-        },
-        "oic.collection.tagged-setoflinks": {
-            "type": "array",
-            "description": "A tagged link is a set (array) of links that are tagged with one or more key-value pairs usually either an ID or Name or both",
-            "items": [
-                {
-                    "$ref": "#/definitions/oic.collection.tags"
-                },
-                {
-                    "$ref": "#/definitions/oic.collection.setoflinks"
-                }
-            ],
-            "additionalItems": false
-        },
-        "oic.collection.setof-tagged-setoflinks": {
-            "type": "array",
-            "items": [
-                {
-                    "$ref": "#/definitions/oic.collection.tagged-setoflinks"
-                }
-            ],
-            "additionalItems": false
-        },
         "oic.collection.alllinks": {
             "description": "All forms of links in a collection",
             "oneOf": [
-                {
-                    "$ref": "#/definitions/oic.collection.setof-tagged-setoflinks"
-                },
-                {
-                    "$ref": "#/definitions/oic.collection.tagged-setoflinks"
-                },
                 {
                     "$ref": "#/definitions/oic.collection.setoflinks"
                 }

--- a/schemas/oic.collection.batch-retrieve-schema.json
+++ b/schemas/oic.collection.batch-retrieve-schema.json
@@ -11,11 +11,23 @@
             "href": {
               "type": "string",
               "description": "URI of the target resource relative assuming the collection URI as anchor"
-            }
+            },
+            "rep": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "description": "The response payload from a single resource"
+                },
+                {
+                  "type": "array",
+                  "description": " The response payload from a collection (batch) resource"
+                }
+            ]
          },
-         "additionalProperties": true,
+         "additionalProperties": false,
          "required": [
-            "href"
+            "href",
+            "rep"
          ]
     }
 }

--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -13,9 +13,15 @@
           "format": "uri"
         },
         "rel": {
-          "type": "string",
-          "default": "hosts",
-          "maxLength": 64,
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "maxLength": 64
+            }
+          ],
+          "minItems": 1,
+          "default": ["hosts"],
           "description": "The relation of the target URI referenced by the link to the context URI"
         },
         "rt": {

--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -50,7 +50,7 @@
         },
         "di": {
            "$ref": "oic.types-schema.json#/definitions/uuid",
-           "description": "Unique identifier for device (UUID)",
+           "description": "Unique identifier for device (UUID)"
         },
         "buri": {
     	    "type": "string",
@@ -111,7 +111,7 @@
             },
             {
               "$ref": "oic.types-schema.json#/definitions/uuid",
-              "description": "Unique identifier (UUID)",
+              "description": "Unique identifier (UUID)"
             }
           ],
           "description": "The instance identifier for this web link in an array of web links - used in collections"

--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -49,9 +49,8 @@
           "description": "The interface set supported by this resource"
         },
         "di": {
-           "type": "string",
-           "description": "The Device ID on which the Relative Reference in href is to be resolved on. Base URI should be used in preference where possible",
-           "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+           "$ref": "oic.types-schema.json#/definitions/uuid",
+           "description": "Unique identifier for device (UUID)",
         },
         "buri": {
     	    "type": "string",
@@ -111,9 +110,8 @@
               "description": "Any unique string including a URI"
             },
             {
-              "type": "string",
-              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-              "description": "Use UUID for universal uniqueness - used in /oic/res to identify the device"
+              "$ref": "oic.types-schema.json#/definitions/uuid",
+              "description": "Unique identifier (UUID)",
             }
           ],
           "description": "The instance identifier for this web link in an array of web links - used in collections"

--- a/schemas/oic.oic-link-schema.json
+++ b/schemas/oic.oic-link-schema.json
@@ -33,7 +33,6 @@
             }
           ],
           "minItems" : 1,
-          "readOnly": true,
           "description": "Resource Type"
         },
         "if": {
@@ -45,7 +44,6 @@
             }
           ],
           "minItems": 1,
-          "readOnly": true,
           "description": "The interface set supported by this resource"
         },
         "di": {
@@ -59,23 +57,19 @@
           "format": "uri"
         },
         "p": {
-          "readOnly": true,
           "description": "Specifies the framework policies on the Resource referenced by the target URI",
           "type": "object",
           "properties": {
             "bm": {
-              "readOnly": true,
               "description": "Specifies the framework policies on the Resource referenced by the target URI for e.g. observable and discoverable",
               "type": "integer"
             },
             "sec": {
-              "readOnly": true,
               "description": "Specifies if security needs to be turned on when looking to interact with the Resource",
               "default": false,
               "type": "boolean"
             },
             "port": {
-              "readOnly": true,
               "description": "Secure port to be used for connection",
               "type": "integer"
             }


### PR DESCRIPTION
As per the discussion in atg October 24, 2016, removed link tagging and
added the "rep" keyword to the batch representation
