### PR TITLE
Fix for invalid json schema

### DIFF
--- a/schemas/oic.collection.batch-retrieve-schema.json
+++ b/schemas/oic.collection.batch-retrieve-schema.json
@@ -23,11 +23,12 @@
                   "description": " The response payload from a collection (batch) resource"
                 }
             ]
-         },
-         "additionalProperties": false,
-         "required": [
-            "href",
-            "rep"
-         ]
+         }
+       },
+       "additionalProperties": false,
+       "required": [
+          "href",
+          "rep"
+       ]
     }
 }


### PR DESCRIPTION
Fix for missing closing bracket in oic.collection.batch-retrive-schema.json