### PR TITLE
Bugzilla1456-InterfaceSupportfor-/oic/mnt

### DIFF
--- a/oic.wk.mnt.raml
+++ b/oic.wk.mnt.raml
@@ -17,7 +17,7 @@ traits:
   - interface:
       queryParameters:
         if:
-          enum: ["oic.if.r","oic.if.rw","oic.if.baseline"]
+          enum: ["oic.if.rw","oic.if.r","oic.if.baseline"]
 
 /oic/mnt:
   displayName: Maintenance
@@ -35,7 +35,7 @@ traits:
     description: Retrieve the maintenance action status
     queryParameters:
       if:
-        enum: ["oic.if.r","oic.if.rw","oic.if.baseline"]
+        enum: ["oic.if.rw","oic.if.r","oic.if.baseline"]
     responses:
       200:
         body:

--- a/oic.wk.mnt.raml
+++ b/oic.wk.mnt.raml
@@ -17,7 +17,7 @@ traits:
   - interface:
       queryParameters:
         if:
-          enum: ["oic.if.r", "oic.if.baseline"]
+          enum: ["oic.if.r","oic.if.rw","oic.if.baseline"]
 
 /oic/mnt:
   displayName: Maintenance
@@ -35,7 +35,7 @@ traits:
     description: Retrieve the maintenance action status
     queryParameters:
       if:
-        enum: ["oic.if.r"]
+        enum: ["oic.if.r","oic.if.baseline"]
     responses:
       200:
         body:
@@ -54,7 +54,7 @@ traits:
       Set the maintenance action(s)
     queryParameters:
       if:
-        enum: ["oic.if.rw"]
+        enum: ["oic.if.rw","oic.if.baseline"]
     body:
       application/json:
         schema: MNT

--- a/oic.wk.mnt.raml
+++ b/oic.wk.mnt.raml
@@ -23,7 +23,7 @@ traits:
   displayName: Maintenance
   is: [ interface ]
   description: |
-    The resource through which an Device is maintained and can be used for diagnostic purposes.
+    The resource through which a Device is maintained and can be used for diagnostic purposes.
     fr (Factory Reset) is a boolean.
       The value 0 means No action (Default), the value 1 means Start Factory Reset
     After factory reset, this value shall be changed back to the default value
@@ -44,7 +44,6 @@ traits:
             example: |
               {
                 "rt":   ["oic.wk.mnt"],
-                "n":    "My Maintenance Actions",
                 "fr":   false,
                 "rb":   false
               }

--- a/oic.wk.mnt.raml
+++ b/oic.wk.mnt.raml
@@ -35,7 +35,7 @@ traits:
     description: Retrieve the maintenance action status
     queryParameters:
       if:
-        enum: ["oic.if.r","oic.if.baseline"]
+        enum: ["oic.if.r","oic.if.rw","oic.if.baseline"]
     responses:
       200:
         body:

--- a/schemas/oic.wk.mnt-schema.json
+++ b/schemas/oic.wk.mnt-schema.json
@@ -10,11 +10,6 @@
         {"required": ["rb"]}
       ],
       "properties": {
-        "n": {
-          "type" : "string",
-          "maxLength" : 64,
-          "description": "Name"
-        },
         "fr":{
           "type": "boolean",
           "description": "Factory Reset"

--- a/schemas/oic.wk.mnt-schema.json
+++ b/schemas/oic.wk.mnt-schema.json
@@ -5,6 +5,10 @@
   "definitions": {
     "oic.wk.mnt": {
       "type": "object",
+      "oneOf": [
+        {"required": ["fr"]},
+        {"required": ["rb"]}
+      ],
       "properties": {
         "n": {
           "type" : "string",
@@ -26,6 +30,5 @@
   "allOf": [
     { "$ref": "oic.core-schema.json#/definitions/oic.core"},
     { "$ref": "#/definitions/oic.wk.mnt" }
-  ],
-  "required": ["fr"]
+  ]
 }


### PR DESCRIPTION
/oic/mnt is update-able by definition, however "oic.if.rw" was missing from the supported set of interfaces for the resource,