### PR TITLE
Updates to align language support to the specification text

### DIFF
--- a/oic.wk.con.raml
+++ b/oic.wk.con.raml
@@ -13,7 +13,9 @@ documentation:
 
 schemas:
   - Configuration: !include schemas/oic.wk.con-schema.json
+  - Conf_Platform: !include schemas/oic.wk.con.p-schema.json
   - Update: !include schemas/oic.wk.con-Update-schema.json
+  - Update_Platform: !include schemas/oic.wk.con-Update-schema.json
 
 traits:
   - interface-all:
@@ -25,7 +27,7 @@ traits:
         if:
           enum: ["oic.if.rw"]
 
-/oic/con:
+/example/oic/con:
   displayName: OIC Configuration
   description: |
     Resource that allows for device specific information to be configured.
@@ -41,12 +43,14 @@ traits:
             schema: Configuration
             example: |
               {
-                "rt":   ["oic.wk.con"],
                 "n":    "My Friendly Device Name",
+                "rt":   ["oic.wk.con", "oic.wk.con.p"],
                 "loc":  [32.777,-96.797],
                 "locn": "My Location Name",
                 "c":    "USD",
-                "r":    "MyRegion"
+                "r":    "MyRegion",
+                "dl":   "en",
+                "mnpn": [ { "language": "en", "value": "My Friendly Device Name" } ]
               }
 
   post:
@@ -58,8 +62,11 @@ traits:
             schema: Update
             example: |
                 {
-                    "n": "My New Friendly Name",
-                    "r":  "MyNewRegion"
+                    "n": "Nuevo Nombre Amistoso",
+                    "r": "MyNewRegion",
+                    "ln": [ { "language": "es", "value": "Nuevo Nombre Amistoso" } ],
+                    "dl": "es",
+                    "mnpn": [ { "language": "es", "value": "Nuevo nombre de Plataforma Amigable" } ]
                 }
     responses:
       200:
@@ -67,6 +74,10 @@ traits:
           application/json:
             schema: Update
             example: |
-                {
-                    "r":  "MyNewRegion"
-                }
+              {
+                  "n": "Nuevo Nombre Amistoso",
+                  "r": "MyNewRegion",
+                  "ln": [ { "language": "es", "value": "Nuevo Nombre Amistoso" } ],
+                  "dl":   "es",
+                  "mnpn": [ { "language": "es", "value": "Nuevo nombre de Plataforma Amigable" } ]
+              }

--- a/schemas/oic.wk.con-Update-schema.json
+++ b/schemas/oic.wk.con-Update-schema.json
@@ -29,6 +29,30 @@
           "type": "string",
           "maxLength": 64,
           "description": "Region"
+        },
+        "ln": {
+          "type": "array",
+          "items" :
+            {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "$ref": "oic.types-schema.json#/definitions/language-tag",
+                  "description": "An RFC 5646 language tag."
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Device description in the indicated language."
+                }
+              }
+            },
+          "minItems" : 1,
+          "description": "Localized names"
+        },
+        "dl": {
+          "$ref": "oic.types-schema.json#/definitions/language-tag",
+          "description": "Default Language"
         }
       }
     }

--- a/schemas/oic.wk.con-schema.json
+++ b/schemas/oic.wk.con-schema.json
@@ -29,6 +29,30 @@
           "type": "string",
           "maxLength": 64,
           "description": "Region"
+        },
+        "ln": {
+          "type": "array",
+          "items" :
+            {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "$ref": "oic.types-schema.json#/definitions/language-tag",
+                  "description": "An RFC 5646 language tag."
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Device description in the indicated language."
+                }
+              }
+            },
+          "minItems" : 1,
+          "description": "Localized names"
+        },
+        "dl": {
+          "$ref": "oic.types-schema.json#/definitions/language-tag",
+          "description": "Default Language"
         }
       }
     }

--- a/schemas/oic.wk.con.p-Update-schema.json
+++ b/schemas/oic.wk.con.p-Update-schema.json
@@ -1,0 +1,36 @@
+{
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.wk.con.p-Update-schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description" : "Copyright (c) 2016 Open Connectivity Foundation, Inc. All rights reserved.",
+  "definitions": {
+    "oic.wk.con.p": {
+      "type": "object",
+      "properties": {
+        "mnpn": {
+          "type": "array",
+          "items" :
+            {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "$ref": "oic.types-schema.json#/definitions/language-tag",
+                  "description": "An RFC 5646 language tag."
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Platform description in the indicated language."
+                }
+              }
+            },
+          "minItems" : 1,
+          "description": "Platform names"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "allOf": [
+    { "$ref": "#/definitions/oic.wk.con.p" }
+  ]
+}

--- a/schemas/oic.wk.con.p-schema.json
+++ b/schemas/oic.wk.con.p-schema.json
@@ -1,0 +1,36 @@
+{
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.wk.con.p-schema.json#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description" : "Copyright (c) 2016, 2017 Open Connectivity Foundation, Inc. All rights reserved.",
+  "definitions": {
+    "oic.wk.con.p": {
+      "type": "object",
+      "properties": {
+        "mnpn": {
+          "type": "array",
+          "items" :
+            {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "$ref": "oic.types-schema.json#/definitions/language-tag",
+                  "description": "An RFC 5646 language tag."
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "description": "Platform description in the indicated language."
+                }
+              }
+            },
+          "minItems" : 1,
+          "description": "Platform names"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "allOf": [
+    { "$ref": "#/definitions/oic.wk.con.p" }
+  ]
+}

--- a/schemas/oic.wk.d-schema.json
+++ b/schemas/oic.wk.d-schema.json
@@ -24,38 +24,8 @@
           "description": "Spec versions of the Resource and Device Specifications to which this device data model is implemented"
         },
         "ld": {
-            "type": "array",
-            "items" : [
-              {
-                "type": "object",
-                "properties": {
-                  "language": {
-                    "$ref": "oic.types-schema.json#/definitions/language-tag",
-                    "readOnly": true,
-                    "description": "An RFC 5646 language tag."
-                  },
-                  "value": {
-                    "type": "string",
-                    "maxLength": 64,
-                    "readOnly": true,
-                    "description": "Device description in the indicated language."
-                  }
-                }
-              }
-            ],
-            "minItems" : 1,
-            "readOnly": true,
-            "description": "Localized Description."
-        },
-        "sv": {
-          "type": "string",
-          "maxLength": 64,
-          "readOnly": true,
-          "description": "Software version."
-        },
-        "dmn": {
           "type": "array",
-          "items" : [
+          "items" :
             {
               "type": "object",
               "properties": {
@@ -71,8 +41,36 @@
                   "description": "Device description in the indicated language."
                 }
               }
-            }
-          ],
+            },
+          "minItems" : 1,
+          "readOnly": true,
+          "description": "Localized Description."
+        },
+        "sv": {
+          "type": "string",
+          "maxLength": 64,
+          "readOnly": true,
+          "description": "Software version."
+        },
+        "dmn": {
+          "type": "array",
+          "items" :
+            {
+              "type": "object",
+              "properties": {
+                "language": {
+                  "$ref": "oic.types-schema.json#/definitions/language-tag",
+                  "readOnly": true,
+                  "description": "An RFC 5646 language tag."
+                },
+                "value": {
+                  "type": "string",
+                  "maxLength": 64,
+                  "readOnly": true,
+                  "description": "Device description in the indicated language."
+                }
+              }
+            },
           "minItems" : 1,
           "readOnly": true,
           "description": "Localized Description."


### PR DESCRIPTION
Fixed incorrect use of "arrays" and added the language support to
/example/oic/con resource (was accidentally omitted).