### PR TITLE
BZ 1696 

### DIFF
--- a/oic.wk.col.raml
+++ b/oic.wk.col.raml
@@ -40,6 +40,11 @@ schemas:
   - slinks: !include schemas/oic.collection.linkslist-schema.json
 
 traits:
+  - interface-all:
+      queryParameters:
+        if:
+          enum: ["oic.if.ll", "oic.if.baseline", "oic.if.b"]
+
   - interface-baseline:
       queryParameters:
         if:


### PR DESCRIPTION
Create interface-all trait for collections to explicitly identify the default interface.