### PR TITLE
Update Easy Setup Resources as per CTWG feedback.

### DIFF
--- a/oic.r.easysetup.raml
+++ b/oic.r.easysetup.raml
@@ -237,8 +237,8 @@ traits:
                 {
                   "href": "/WiFiConfResURI",
                   "rep" : {
-                    "swmt" : [0, 1, 2],
-                    "swf": "Both",
+                    "swmt" : ["A", "B", "G"],
+                    "swf": ["2.4G", "5G"],
                     "tnn": "Home_AP_SSID",
                     "cd": "Home_AP_PWD",
                     "wat": "WPA2-PSK",

--- a/oic.r.wificonf.raml
+++ b/oic.r.wificonf.raml
@@ -47,12 +47,14 @@ traits:
             example: |
               {
                 "rt": ["oic.r.wificonf"],
-                "swmt" : [0, 1, 2],
-                "swf": "Both",
+                "swmt" : ["A", "B", "G"],
+                "swf": ["2.4G", "5G"],
                 "tnn": "Home_AP_SSID",
                 "cd": "Home_AP_PWD",
                 "wat": "WPA2-PSK",
-                "wet": "TKIP"
+                "wet": "TKIP",
+                "swat": ["WPA-PSK", "WPA2-PSK"],
+                "swet": ["TKIP", "AES", "TKIP_AES"]
               }
 
   post:

--- a/schemas/oic.r.devconf-schema.json
+++ b/schemas/oic.r.devconf-schema.json
@@ -1,19 +1,48 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "http://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.devconf-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.devconf-schema.json#",
   "definitions": {
     "oic.r.devconf": {
       "type": "object",
-      "properties": {
-        "dn": {
-          "type": "string",
-          "description": "Indicates a pre-configured device name presented by
-          enrollee device to mediator device during easy-setup process",
-          "readOnly": true
+      "oneOf": [
+        {
+          "properties": {
+            "dn": {
+              "type": "string",
+              "description": "Indicates a pre-configured device name in language indicated by 'dl' in /oic/con;  presented by enrollee device to mediator device during easy-setup process",
+              "readOnly": true
+            }
+          },
+          "required":["dn"]
+        },
+        {
+          "properties": {
+            "dn": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "language": {
+                    "$ref": "oic.types-schema.json#/definitions/language-tag",
+                    "readOnly": true,
+                    "description": "An RFC 5646 language tag."
+                  },
+                  "value": {
+                    "type": "string",
+                    "readOnly": true,
+                    "description": "Pre-configured device name in the indicated language."
+                  }
+                }
+              },
+              "minItems" : 1,
+              "readOnly": true,
+              "description": "Localized device name."
+            }
+          },
+          "required": ["dn"]
         }
-      },
-      "required":["dn"]
+      ]
     }
   },
   "type": "object",

--- a/schemas/oic.r.easysetup-schema.json
+++ b/schemas/oic.r.easysetup-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "http://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.easysetup-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.easysetup-schema.json#",
   "definitions": {
     "oic.r.easysetup": {
       "type": "object",
@@ -51,11 +51,11 @@
                 "description": "Connection type to attempt. (1 : Wi-Fi, 2 : other entities / transports to be added in future (e.g. Connect to cloud / BLE))"
               }
             }
-          }
+          },
+          "required": ["ps", "lec", "cn"]
         }
       ]
-    },
-    "required": ["ps", "lec", "cn"]
+    }
   },
   "type": "object",
   "allOf": [

--- a/schemas/oic.r.wificonf-schema.json
+++ b/schemas/oic.r.wificonf-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "http://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.wificonf-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.wificonf-schema.json#",
   "definitions": {
     "oic.r.wificonf": {
       "type": "object",
@@ -12,15 +12,22 @@
           "readOnly": true,
           "items": [
             {
-              "type": "integer",
-              "description": "Supported Wi-Fi Mode Type. i.e. 0: A, 1: B, 2: G, 3: N, 4: AC"
+              "type": "string",
+              "enum": ["A","B","G","N","AC"],
+              "description": "Supported Wi-Fi Mode Type."
             }
           ]
         },
         "swf": {
-          "enum": ["2.4G", "5G", "Both"],
+          "type": "array",
           "description": "Indicates supported Wi-Fi frequency",
-          "readOnly": true
+          "readOnly": true,
+          "items": [
+            {
+              "type": "string",
+              "enum": ["2.4G", "5G"]
+            }
+          ]
         },
         "tnn": {
           "type": "string",
@@ -31,12 +38,38 @@
           "description": "Indicates credential information of Wi-Fi AP"
         },
         "wat": {
+          "type": "string",
           "enum": ["None", "WEP", "WPA-PSK", "WPA2-PSK"],
           "description": "Indicates Wi-Fi Auth Type"
         },
         "wet": {
+          "type": "string",
           "enum": ["None", "WEP-64", "WEP-128", "TKIP", "AES", "TKIP_AES"],
           "description": "Indicates Wi-Fi Encryption Type"
+        },
+        "swat": {
+          "type": "array",
+          "description": "Indicates supported Wi-Fi Auth types. It can be multiple",
+          "readOnly": true,
+          "items": [
+            {
+              "type": "string",
+              "enum": ["None", "WEP", "WPA-PSK", "WPA2-PSK"],
+              "description": "Indicates Wi-Fi Auth Type"
+            }
+          ]
+        },
+        "swet": {
+          "type": "array",
+          "description": "Indicates supported Wi-Fi Encryption types. It can be multiple",
+          "readOnly": true,
+          "items": [
+            {
+              "type": "string",
+              "enum": ["None", "WEP-64", "WEP-128", "TKIP", "AES", "TKIP_AES"],
+              "description": "Indicates Wi-Fi Encryption Type"
+            }
+          ]
         }
       },
       "required":["swmt", "swf", "tnn"]

--- a/schemas/oic.r.wificonf-update-schema.json
+++ b/schemas/oic.r.wificonf-update-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-v4/schema#",
   "description" : "Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "http://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.wificonf-update-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.r.wificonf-update-schema.json#",
   "definitions": {
     "oic.r.wificonf": {
       "type": "object",


### PR DESCRIPTION
- change integer enum to string
- oic.r.wificonf: make "swf" property to be array of string instead of
integer
- oic.r.wificonf: add optional properties "swat" and "swet"
- oic.r.devconf: update "dn" property to include localization.
- oic.r.easysetup: fix schema error