### PR TITLE
[Easy Setup] Update WiFiConf validations.

### DIFF
--- a/oic.r.easysetup.raml
+++ b/oic.r.easysetup.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Easy Setup Resource
-version: v0.0.2-20170604
+version: v0.0.3-20170611
 documentation:
   - title: OCF Copyright
     content: Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.
@@ -123,8 +123,8 @@ traits:
                 {
                   "href": "/WiFiConfResURI",
                   "rep":{
-                    "swmt" : [0, 1, 2],
-                    "swf": "Both",
+                    "swmt" : ["A", "B", "G"],
+                    "swf": ["2.4G", "5G"],
                     "tnn": "Home_AP_SSID",
                     "cd": "Home_AP_PWD",
                     "wat": "WPA2_PSK",

--- a/oic.r.wificonf.raml
+++ b/oic.r.wificonf.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Wi-Fi Configuration Resource
-version: v0.0.2-20170604
+version: v0.0.3-20170611
 documentation:
   - title: OCF Copyright
     content: Copyright (c) 2017 Open Connectivity Foundation, Inc. All rights reserved.
@@ -49,7 +49,7 @@ traits:
               {
                 "rt": ["oic.r.wificonf"],
                 "swmt" : ["A", "B", "G"],
-                "swf": ["2_4G", "5G"],
+                "swf": ["2.4G", "5G"],
                 "tnn": "Home_AP_SSID",
                 "cd": "Home_AP_PWD",
                 "wat": "WPA2_PSK",

--- a/schemas/oic.r.wificonf-schema.json
+++ b/schemas/oic.r.wificonf-schema.json
@@ -10,24 +10,22 @@
           "type": "array",
           "description": "Indicates supported Wi-Fi mode types. It can be multiple",
           "readOnly": true,
-          "items": [
+          "items":
             {
               "type": "string",
               "enum": ["A","B","G","N","AC"],
               "description": "Supported Wi-Fi Mode Type."
             }
-          ]
         },
         "swf": {
           "type": "array",
-          "description": "Indicates supported Wi-Fi frequency",
+          "description": "Indicates Supported Wi-Fi frequencies by the Enrollee. Can be multiple. Valid values are ('2.4G', '5G')",
           "readOnly": true,
-          "items": [
+          "items":
             {
               "type": "string",
-              "enum": ["2_4G", "5G"]
+              "pattern": "^(2\\.4|5)G$"
             }
-          ]
         },
         "tnn": {
           "type": "string",
@@ -53,25 +51,23 @@
           "type": "array",
           "description": "Indicates supported Wi-Fi Auth types. It can be multiple",
           "readOnly": true,
-          "items": [
+          "items":
             {
               "type": "string",
               "enum": ["None", "WEP", "WPA_PSK", "WPA2_PSK"],
               "description": "Indicates Wi-Fi Auth Type"
             }
-          ]
         },
         "swet": {
           "type": "array",
           "description": "Indicates supported Wi-Fi Encryption types. It can be multiple",
           "readOnly": true,
-          "items": [
+          "items":
             {
               "type": "string",
               "enum": ["None", "WEP_64", "WEP_128", "TKIP", "AES", "TKIP_AES"],
               "description": "Indicates Wi-Fi Encryption Type"
             }
-          ]
         }
       },
       "required":["swmt", "swf", "swat", "swet", "tnn", "wat", "wet"]


### PR DESCRIPTION
oic.r.wificonf: "swf" property: Change validation from enum to regex.
oic.r.wificonf: "swf" property: Change value option "2_4G" to "2.4G".
oic.r.wificonf: Fix some incorrectly validated array properties.
oic.r.easysetup: Update examples of WifiConf.