### PR TITLE
Updated displayName for wificonf and coapcloudconf URIs

### DIFF
--- a/oic.r.coapcloudconf.raml
+++ b/oic.r.coapcloudconf.raml
@@ -29,7 +29,7 @@ traits:
   description: |
     CoAPCloudConf resource exposes configuration information for connecting to a
     cloud server.
-  displayName: CoAP Cloud Configuration
+  displayName: CoAP Cloud Configuration Resource Baseline Interface
   is: [ interface-baseline ] # valid for baseline method.
 
   get:
@@ -86,7 +86,7 @@ traits:
   description: |
     CoAPCloudConf resource exposes configuration information for connecting to a
     cloud server.
-  displayName: CoAP Cloud Configuration
+  displayName: CoAP Cloud Configuration Resource Read Write Interface
   is: [ interface-rw ] # valid for RW method.
 
   get:

--- a/oic.r.wificonf.raml
+++ b/oic.r.wificonf.raml
@@ -29,7 +29,7 @@ traits:
     WiFiConf resource stores essential information to help an unboxing device
     to connect to an existing Wi-Fi AP.
 
-  displayName: Wi-Fi Configuration
+  displayName: Wi-Fi Configuration Resource Baseline Interface
   is: [ interface-baseline ]
 
   get:
@@ -90,7 +90,7 @@ traits:
     WiFiConf resource stores essential information to help an unboxing device
     to connect to an existing Wi-Fi AP.
 
-  displayName: Wi-Fi Configuration
+  displayName: Wi-Fi Configuration Resource Read Write Interface
   is: [ interface-rw ]
 
   get:


### PR DESCRIPTION
- Updated with separate displayName so that appendices in raml2doc output can be differentiated.

Please review and merge if appropriate.