### PR TITLE
Changes for Bugzilla 1732

### DIFF
--- a/schemas/oic.types-schema.json
+++ b/schemas/oic.types-schema.json
@@ -13,6 +13,11 @@
             "type": "string",
             "pattern": "^([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|2[0-9]|1[0-9]|0[1-9])$"
         },
+        "duration": {
+            "description": "A string representing duration formatted as defined in ISO 8601. Allowable formats are: P[n]Y[n]M[n]DT[n]H[n]M[n]S, P[n]W, P[n]Y[n]-M[n]-DT[0-23]H[0-59]:M[0-59]:S, and P[n]W, P[n]Y[n]M[n]DT[0-23]H[0-59]M[0-59]S. P is mandatory, all other elements are optional, time elements must follow a T.",
+            "type": "string",
+            "pattern": "^(P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?((T(?=\d+[HMS])(\d+H)?(\d+M)?(\d+S)?)?))$|^(P\d+W)$|^(P[0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|2[0-9]|1[0-9]|0[1-9])T(2[0-3]|1[0-9]|0[1-9]):([0-5][0-9]):([0-5][0-9])$|^(P[0-9]{4})(1[0-2]|0[1-9])(3[0-1]|2[0-9]|1[0-9]|0[1-9])T(2[0-3]|1[0-9]|0[1-9])([0-5][0-9])([0-5][0-9])$"
+        },
         "language-tag": {
           "description": "An identifier formatted according to IETF RFC 5646 (langusge tag).",
           "type": "string",


### PR DESCRIPTION
Adds duration type in oic.types-schema.json to align with ISO 8601