### PR TITLE
Corrections to the schema for Scenes as per BZ1692

### DIFF
--- a/scene.raml
+++ b/scene.raml
@@ -72,7 +72,7 @@ traits:
                         example: |
                             {
                                 "lastScene": "off",
-                                "sceneValues": "off,Reading,TVWatching",
+                                "sceneValues": ["off","Reading","TVWatching"],
                                 "rt":       ["oic.wk.scenecollection"],
                                 "n":        "My Scenes for my living room",
                                 "id":       "0685B960-736F-46F7-BEC0-9E6CBD671ADC1",

--- a/schemas/oic.sceneCollection-Update-schema.json
+++ b/schemas/oic.sceneCollection-Update-schema.json
@@ -1,51 +1,30 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description" : "Copyright (c) 2016, 2017 Open Connectivity Foundation, Inc. All rights reserved.",
-  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.sceneCollection-schema.json#",
+  "id": "https://www.openconnectivity.org/ocf-apis/core/schemas/oic.sceneCollection-Update-schema.json#",
   "title" : "Scene Collection",
   "definitions": {
-    "oic.sceneCollection": {
+    "oic.sceneCollection-Update": {
       "type": "object",
-      "properties": {
-        "lastScene": {
-          "type": "string",
-          "description": "Last selected Scene, shall be part of sceneValues"
+      "allOf": [
+        {
+          "$ref": "oic.collection-schema.json#/definitions/oic.collection"
         },
-        "sceneValues": {
-          "type": "string",
-          "readOnly": true,
-          "description": "All available scene values"
-        },
-        "n": {
-          "type": "string",
-          "description": "Used to name the Scene collection"
-        },
-        "id": {
-            "type": "string",
-                        "description" : "A unique string that could be a hash or similarly unique"
-        },
-        "rts": {
-          "$ref": "oic.core-schema.json#/definitions/oic.core/properties/rt",
-          "description": "Defines the list of allowable resource types in links included in the collection; new links being created can only be from this list"
-        },
-        "links": {
-          "type": "array",
-          "description": "Array of OIC web links that are reference from this collection",
-          "items" : {
-            "allOf": [
-              { "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link" },
-              { "required" : [ "ins" ] }
-            ]
+        {
+          "properties": {
+            "lastScene": {
+              "type": "string",
+              "description": "Last selected Scene, shall be part of sceneValues"
+            }
           }
         }
-      },
+      ],
       "required": [ "lastScene" ]
     }
   },
-
   "type": "object",
   "allOf" : [
     { "$ref": "oic.core-schema.json#/definitions/oic.core" },
-    { "$ref": "#/definitions/oic.sceneCollection" }
+    { "$ref": "#/definitions/oic.sceneCollection-Update" }
   ]
 }

--- a/schemas/oic.sceneCollection-Update-schema.json
+++ b/schemas/oic.sceneCollection-Update-schema.json
@@ -14,7 +14,7 @@
           "properties": {
             "lastScene": {
               "type": "string",
-              "description": "Last selected Scene, shall be part of sceneValues"
+              "description": "Last selected Scene from the set of sceneValues"
             }
           }
         }

--- a/schemas/oic.sceneCollection-schema.json
+++ b/schemas/oic.sceneCollection-schema.json
@@ -14,7 +14,7 @@
           "properties": {
             "lastScene": {
               "type": "string",
-              "description": "Last selected Scene, shall be part of sceneValues"
+              "description": "Last selected Scene from the set of sceneValues"
             },
             "sceneValues": {
               "type": "array",

--- a/schemas/oic.sceneCollection-schema.json
+++ b/schemas/oic.sceneCollection-schema.json
@@ -6,43 +6,30 @@
   "definitions": {
     "oic.sceneCollection": {
       "type": "object",
-      "properties": {
-        "lastScene": {
-          "type": "string",
-          "description": "Last selected Scene, shall be part of sceneValues"
+      "allOf": [
+        {
+          "$ref": "oic.collection-schema.json#/definitions/oic.collection"
         },
-        "sceneValues": {
-          "type": "string",
-          "readOnly": true,
-          "description": "All available scene values"
-        },
-        "n": {
-          "type": "string",
-          "description": "Used to name the Scene collection"
-        },
-        "id": {
-            "type": "string",
-                        "description" : "A unique string that could be a hash or similarly unique"
-        },
-        "rts": {
-          "$ref": "oic.core-schema.json#/definitions/oic.core/properties/rt",
-          "description": "Defines the list of allowable resource types in links included in the collection; new links being created can only be from this list"
-        },
-        "links": {
-          "type": "array",
-          "description": "Array of OIC web links that are reference from this collection",
-          "items" : {
-            "allOf": [
-              { "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link" },
-              { "required" : [ "ins" ] }
-            ]
+        {
+          "properties": {
+            "lastScene": {
+              "type": "string",
+              "description": "Last selected Scene, shall be part of sceneValues"
+            },
+            "sceneValues": {
+              "type": "array",
+              "readOnly": true,
+              "description": "All available scene values",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         }
-      },
+      ],
       "required": [ "lastScene","sceneValues","rts","id" ]
     }
   },
-
   "type": "object",
   "allOf" : [
     { "$ref": "oic.core-schema.json#/definitions/oic.core" },

--- a/schemas/oic.sceneMember-schema.json
+++ b/schemas/oic.sceneMember-schema.json
@@ -7,18 +7,10 @@
     "oic.sceneMember": {
       "type": "object",
       "properties": {
-        "n": {
-          "type": "string",
-          "description": "Used to name the Scene collection"
-        },
-        "id": {
-          "type": "string",
-          "description": "Can be an value that is unique to the use context or a UUIDv4"
-        },
         "SceneMappings" : {
           "type": "array",
-           "description": "array of mappings per scene, can be 1",
-          "items": {
+           "description": "array of mappings per scene, can be one(1)",
+           "items": {
               "type": "object",
               "properties": {
                 "scene": {
@@ -30,7 +22,7 @@
                   "readOnly": true,
                   "description": "property name that will be mapped"
                 },
-                  "memberValue": {
+                "memberValue": {
                   "type": "string",
                   "readOnly": true,
                   "description": "value of the Member Property"
@@ -39,11 +31,15 @@
               "required": [ "scene", "memberProperty", "memberValue" ]
             }
         },
-
         "link": {
-          "type": "string",
-          "description": "web link that points at a resource",
-          "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link"
+          "allOf": [
+            {
+              "$ref": "oic.oic-link-schema.json#/definitions/oic.oic-link"
+            },
+            {
+              "description": "OCF link that points to a resource"
+            }
+          ]
         }
       },
       "required": [ "link" ]

--- a/schemas/oic.sceneMember-schema.json
+++ b/schemas/oic.sceneMember-schema.json
@@ -15,7 +15,7 @@
               "properties": {
                 "scene": {
                   "type": "string",
-                  "description": "Specifies a scene value that will acted upon"
+                  "description": "Specifies a scene value that will be acted upon"
                 },
                 "memberProperty": {
                   "type":  "string",


### PR DESCRIPTION
Corrections to the schema for Scenes to model as a specialization of a collection.  Also change sceneValues to a array of strings in line with JSON serialization recommendations.