### PR TITLE
BZ #1874 Remove "di" from the Collection schema

### DIFF
--- a/schemas/oic.collection-schema.json
+++ b/schemas/oic.collection-schema.json
@@ -23,16 +23,6 @@
             "type": "object",
             "description": "A collection is a set of links along with additional properties to describe the collection itself",
             "properties": {
-                "di": {
-                  "allOf": [
-                    {
-                      "$ref": "oic.types-schema.json#/definitions/uuid"
-                    },
-                    {
-                      "description": "The device ID."
-                    }
-                  ]
-                },
                 "rts": {
                   "allOf": [
                     {


### PR DESCRIPTION
As per the 8/8/2017 teleconference remove the "di" property from the
collection schema when using the "baseline" interface.