### PR TITLE
[Easy Setup] Add self link in oic.r.easysetup RAML example

### DIFF
--- a/oic.r.easysetup.raml
+++ b/oic.r.easysetup.raml
@@ -69,6 +69,16 @@ traits:
                 "cn": [1],
                 "links": [
                   {
+                    "href": "/EasySetupResURI",
+                    "rt": ["oic.r.easysetup", "oic.wk.col"],
+                    "if": ["oic.if.ll", "oic.if.baseline", "oic.if.b"],
+                    "p":{"bm":3},
+                    "eps": [
+                      {"ep": "coaps://[fe80::b1d6]:1111", "pri": 2}
+                    ],
+                    "rel":["self", "item"]
+                  },
+                  {
                     "href": "/WiFiConfResURI",
                     "rt":   ["oic.r.wificonf"],
                     "if":   ["oic.if.baseline"],
@@ -229,6 +239,16 @@ traits:
             schema: slinks
             example: |
               [
+                {
+                  "href": "/EasySetupResURI",
+                  "rt": ["oic.r.easysetup", "oic.wk.col"],
+                  "if": ["oic.if.ll", "oic.if.baseline", "oic.if.b"],
+                  "p":{"bm":3},
+                  "eps": [
+                    {"ep": "coaps://[fe80::b1d6]:1111", "pri": 2}
+                  ],
+                  "rel":["self", "item"]
+                },
                 {
                   "href": "/WiFiConfResURI",
                   "rt":   ["oic.r.wificonf"],

--- a/oic.r.easysetup.raml
+++ b/oic.r.easysetup.raml
@@ -71,7 +71,7 @@ traits:
                   {
                     "href": "/EasySetupResURI",
                     "rt": ["oic.r.easysetup", "oic.wk.col"],
-                    "if": ["oic.if.ll", "oic.if.baseline", "oic.if.b"],
+                    "if": ["oic.if.b"],
                     "p":{"bm":3},
                     "eps": [
                       {"ep": "coaps://[fe80::b1d6]:1111", "pri": 2}
@@ -242,7 +242,7 @@ traits:
                 {
                   "href": "/EasySetupResURI",
                   "rt": ["oic.r.easysetup", "oic.wk.col"],
-                  "if": ["oic.if.ll", "oic.if.baseline", "oic.if.b"],
+                  "if": ["oic.if.b"],
                   "p":{"bm":3},
                   "eps": [
                     {"ep": "coaps://[fe80::b1d6]:1111", "pri": 2}


### PR DESCRIPTION
In Easy Setup Baseline and Link List examples:
- Add self link to Easy Setup Resource.
- Add "rel":["self", "item"] property to self link.