### PR TITLE
missing reference to queryparams

### DIFF
--- a/swagger2.0/oic.r.icon.swagger.json
+++ b/swagger2.0/oic.r.icon.swagger.json
@@ -16,6 +16,7 @@
       "get": {
         "description": "This resource describes the attributes associated with an Icon.\nRetrieves the current icon properties.\n",
         "parameters": [
+          {"$ref": "#/parameters/interface"}
         ],
         "responses": {
             "200": {

--- a/swagger2.0/oic.wk.col.swagger.json
+++ b/swagger2.0/oic.wk.col.swagger.json
@@ -16,6 +16,7 @@
       "get": {
         "description": "OCF Collection Resource Type contains properties and links.\nThe oic.if.baseline interface exposes a representation of\nthe links and the properties of the collection resource itself\nRetrieve on Baseline Interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-baseline"}
         ],
         "responses": {
             "200": {
@@ -56,6 +57,7 @@
       "post": {
         "description": "Update on Baseline Interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-baseline"},
           {
             "name": "body",
             "in": "body",
@@ -75,6 +77,7 @@
       "get": {
         "description": "OCF Collection Resource Type contains properties and links.\nThe oic.if.b interfacce exposes a composite representation of the\nresources pointed to by the links\nRetrieve on Batch Interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-b"}
         ],
         "responses": {
             "200": {
@@ -120,6 +123,7 @@
       "post": {
         "description": "Update on Batch Interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-b"},
           {
             "name": "body",
             "in": "body",
@@ -199,6 +203,7 @@
       "get": {
         "description": "OCF Collection Resource Type contains properties and links.\nThe oic.if.ll interface exposes a representation of the links\nRetrieve on Link List Interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-ll"}
         ],
         "responses": {
             "200": {
@@ -569,7 +574,7 @@
                 "type": "string"
               },
               "di": {
-                "description": "Format pattern according to IETF RFC 4122.",
+                "description": "The Device ID formatted according to IETF RFC 4122.",
                 "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                 "type": "string"
               },
@@ -715,8 +720,9 @@
           "type": "string"
         },
         "di": {
-          "$ref": "#/definitions/uuid",
-          "description": "The device ID"
+          "description": "The Device ID formatted according to IETF RFC 4122.",
+          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+          "type": "string"
         },
         "eps": {
           "description": "the Endpoint information of the target Resource",

--- a/swagger2.0/oic.wk.d.swagger.json
+++ b/swagger2.0/oic.wk.d.swagger.json
@@ -16,6 +16,7 @@
       "get": {
         "description": "Known resource that is hosted by every Server.\nAllows for logical device specific information to be discovered.\nRetrieve the information about the Device\n",
         "parameters": [
+          {"$ref": "#/parameters/interface"}
         ],
         "responses": {
             "200": {

--- a/swagger2.0/oic.wk.introspection.swagger.json
+++ b/swagger2.0/oic.wk.introspection.swagger.json
@@ -16,6 +16,7 @@
       "get": {
         "description": "This resource provides the means to get the device introspection data specifiying all the endpoints of the device.\nThe url hosted by this resource is either a local or an external url.\n",
         "parameters": [
+          {"$ref": "#/parameters/interface"}
         ],
         "responses": {
             "200": {

--- a/swagger2.0/oic.wk.p.swagger.json
+++ b/swagger2.0/oic.wk.p.swagger.json
@@ -16,6 +16,7 @@
       "get": {
         "description": "Known resource that is defines the platform on which an Server is hosted.\nAllows for platform specific information to be discovered.\nRetrieve the information about the Platform\n",
         "parameters": [
+          {"$ref": "#/parameters/interface"}
         ],
         "responses": {
             "200": {

--- a/swagger2.0/oic.wk.res.swagger.json
+++ b/swagger2.0/oic.wk.res.swagger.json
@@ -16,6 +16,7 @@
       "get": {
         "description": "Link list representation of /oic/res; list of discoverable resources\nRetrieve the discoverable resource set, link list interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-ll"}
         ],
         "responses": {
             "200": {
@@ -53,6 +54,7 @@
       "get": {
         "description": "Baseline representation of /oic/res; list of discoverable resources\nRetrieve the discoverable resource set, baseline interface\n",
         "parameters": [
+          {"$ref": "#/parameters/interface-baseline"}
         ],
         "responses": {
             "200": {
@@ -126,17 +128,10 @@
             "type": "string"
           },
           "di": {
-            "allOf": [
-              {
                 "description": "Format pattern according to IETF RFC 4122.",
                 "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                 "type": "string"
               },
-              {
-                "description": "The device ID"
-              }
-            ]
-          },
           "eps": {
             "description": "the Endpoint information of the target Resource",
             "items": {
@@ -282,17 +277,10 @@
                   "type": "string"
                 },
                 "di": {
-                  "allOf": [
-                    {
                       "description": "Format pattern according to IETF RFC 4122.",
                       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                       "type": "string"
                     },
-                    {
-                      "description": "The device ID"
-                    }
-                  ]
-                },
                 "eps": {
                   "description": "the Endpoint information of the target Resource",
                   "items": {


### PR DESCRIPTION
- raml2doc fixed
- manually merged from output of raml2doc