### PR TITLE
BZ #1941 - improve reference to date specification

### DIFF
--- a/schemas/oic.types-schema.json
+++ b/schemas/oic.types-schema.json
@@ -9,7 +9,7 @@
             "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
         },
         "date": {
-            "description": "Format pattern as defined in ISO 8601. The format is [yyyy]-[mm]-[dd].",
+            "description": "The full-date format pattern according to IETF RFC 3339",
             "type": "string",
             "pattern": "^([0-9]{4})-(1[0-2]|0[1-9])-(3[0-1]|2[0-9]|1[0-9]|0[1-9])$"
         },

--- a/schemas/oic.wk.p-schema.json
+++ b/schemas/oic.wk.p-schema.json
@@ -43,7 +43,7 @@
             },
             {
               "readOnly": true,
-              "description": "Manufacturing Date in ISO8601 format."
+              "description": "Manufacturing Date."
             }
           ]
         },
@@ -81,7 +81,7 @@
         "st": {
           "type": "string",
           "readOnly": true,
-          "description": "Reference time for the device in ISO8601 format.",
+          "description": "The date-time format pattern according to IETF RFC 3339.",
           "format": "date-time"
         },
         "vid": {


### PR DESCRIPTION
Change reference for date-time & date from ISO 8601 to IETF RFC 3339.