### PR TITLE
 BZ #2011 - Editorial Update for "rx" and "tx" Property Descriptions

### DIFF
--- a/schemas/oic.wk.nmon-schema.json
+++ b/schemas/oic.wk.nmon-schema.json
@@ -28,13 +28,13 @@
         "tx" :
         {
             "type" : "integer",
-            "description": "Amount of transmitted kilo bytes from collection start time 'time'",
+            "description": "Amount of transmitted kilo bytes from the collection",
             "readOnly" : true
         },
         "rx" :
         {
             "type" : "integer",
-            "description": "Amount of received kilo bytes from collection start time 'time'",
+            "description": "Amount of received kilo bytes from the collection",
             "readOnly" : true
         },
         "mmstx" :


### PR DESCRIPTION
Removed reference to non-existent "time" Property from the description
for the "rx" and "tx" Properties.  The "time" Property was removed in an
earlier revision of the schema. Discussed during the 5/22/18 ATG Teleconference.