### PR TITLE
Fix for incomplete $ref oic.links.properties.core-schema.json

### DIFF
--- a/schemas/oic.links.properties.core-schema.json
+++ b/schemas/oic.links.properties.core-schema.json
@@ -33,7 +33,7 @@
           "format": "uri"
       },
       "di": {
-          "$ref": "https://openconnectivityfoundation.github.io/core/schemas/oic.types-schema.json",
+          "$ref": "https://openconnectivityfoundation.github.io/core/schemas/oic.types-schema.json#/definitions/uuid",
           "description": "The device ID."
       },
       "p": {


### PR DESCRIPTION
The $ref in the definition of "di" property in line 36 points to the root of schema file oic.types-schema.json, while it should point further to path /definitions/uuid inside the target schema file.