### PR TITLE
Update oic.wk.d.swagger.json

### DIFF
--- a/swagger2.0/oic.wk.d.swagger.json
+++ b/swagger2.0/oic.wk.d.swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Device",
-    "version": "2019-03-04",
+    "version": "2019-03-13",
     "license": {
       "name": "OCF Data Model License",
       "url": "https://openconnectivityfoundation.github.io/core/LICENSE.md",
@@ -36,7 +36,7 @@
                 "n":    "Device 1",
                 "rt":   ["oic.wk.d"],
                 "di":   "54919CA5-4101-4AE4-595B-353C51AA983C",
-                "icv":  "ocf.2.0.0",
+                "icv":  "ocf.2.0.2",
                 "dmv":  "ocf.res.1.0.0, ocf.sh.1.0.0",
                 "piid": "6F0AAC04-2BB0-468D-B57C-16570A26AE48"
               },
@@ -62,7 +62,6 @@
         "rt":  {
           "description": "Resource Type of the Resource",
           "items": {
-            "enum": ["oic.wk.d"],
             "type": "string",
             "maxLength": 64
           },


### PR DESCRIPTION
Removed the restriction on "rt" to contain "oic.wk.d" as "oic.d.thing" only is allowed.  Changed "icv" value to the current version of the specification "ocf.2.0.2" for completeness.