### PR TITLE
Bugzilla #2647 - New "mnnct" Property

### DIFF
--- a/swagger2.0/oic.wk.p.swagger.json
+++ b/swagger2.0/oic.wk.p.swagger.json
@@ -157,8 +157,18 @@
           "readOnly": true,
           "uniqueItems": true,
           "type": "array"
+        },
+        "mnnct" : {
+           "description": "An array of integers and each integer indicates the network connectivity type based on IANAIfType value as defined by: https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib, e.g., [71, 259] which represents Wi-Fi and Zigbee.",
+           "items": {
+             "type": "integer",
+             "minimum": 1,
+             "description": "The network connectivity type based on IANAIfType value as defined by: https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib."
+           },
+          "minItems": 1,
+          "readOnly": true,
+          "type": "array"
         }
-
       },
       "type" : "object",
       "required": ["pi", "mnmn"]


### PR DESCRIPTION
Addition of a new optional Property to the "/oic/p" Resource. The Property is an array of integers and each integer indicates the network connectivity type based on IANAIfType value as defined by: https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib, e.g., [71, 259] which represents Wi-Fi and Zigbee.